### PR TITLE
Add the underlying type to GoType

### DIFF
--- a/types.go
+++ b/types.go
@@ -52,9 +52,10 @@ type GoMethod struct {
 }
 
 type GoType struct {
-	Name  string
-	Type  string
-	Inner []*GoType
+	Name       string
+	Type       string
+	Underlying string
+	Inner      []*GoType
 }
 
 type GoStruct struct {


### PR DESCRIPTION
Adds the underlying type to GoType. The underlying type for `id` in this example will be `int`
```go
type CustomID int
var id CustomID
```
